### PR TITLE
Fix debugger ports

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -2,7 +2,7 @@
     "name": "elitebgs-backend",
     "scripts": {
         "start": "cross-env PORT=4010 pm2 start process.json --env production",
-        "startdev": "cross-env NODE_ENV=development nodemon --inspect ./bin/start.js"
+        "startdev": "cross-env NODE_ENV=development nodemon --inspect=localhost:9029 ./bin/start.js"
     },
     "private": true,
     "dependencies": {

--- a/eddn_listener/package.json
+++ b/eddn_listener/package.json
@@ -2,7 +2,7 @@
     "name": "elitebgs-eddn-listener",
     "scripts": {
         "start": "cross-env PORT=4011 pm2 start process.json --env production",
-        "startdev": "cross-env NODE_ENV=development nodemon --inspect ./bin/start.js"
+        "startdev": "cross-env NODE_ENV=development nodemon --inspect=localhost:9129 ./bin/start.js"
     },
     "private": true,
     "dependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,7 @@
         "buildprod": "ng build --prod",
         "builddev": "ng build --watch --progress",
         "runprod": "cross-env PORT=4014 pm2 start process.json --env production",
-        "rundev": "cross-env NODE_ENV=development nodemon --inspect ./bin/start.js"
+        "rundev": "cross-env NODE_ENV=development nodemon --inspect=localhost:9429 ./bin/start.js"
     },
     "private": true,
     "dependencies": {

--- a/guild_bot/package.json
+++ b/guild_bot/package.json
@@ -2,7 +2,7 @@
     "name": "elitebgs-guild-bot",
     "scripts": {
         "start": "cross-env PORT=4013 pm2 start process.json --env production",
-        "startdev": "cross-env NODE_ENV=development nodemon --inspect ./bin/start.js"
+        "startdev": "cross-env NODE_ENV=development nodemon --inspect=localhost:9329 ./bin/start.js"
     },
     "private": true,
     "dependencies": {

--- a/tick_listener/package.json
+++ b/tick_listener/package.json
@@ -2,7 +2,7 @@
     "name": "elitebgs-tick-listener",
     "scripts": {
         "start": "cross-env PORT=4012 pm2 start process.json --env production",
-        "startdev": "cross-env NODE_ENV=development nodemon --inspect ./bin/start.js"
+        "startdev": "cross-env NODE_ENV=development nodemon --inspect=localhost:9229 ./bin/start.js"
     },
     "private": true,
     "dependencies": {


### PR DESCRIPTION
Each debug port was trying to use 9229, which is the default debugger port. This changes the debugger port to match the localhost port number (so front end uses 3014, debugger uses 9429).

The associated issue is #