### PR TITLE
Fix api URLs for development and prod

### DIFF
--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -78,7 +78,7 @@ const providers: Provider[] = [
     IngameIdsService,
     {
         provide: 'BASE_API_URL',
-        useValue: environment.baseUrl
+        useValue: environment.apiUrl
     },
     {
         provide: HTTP_INTERCEPTORS,

--- a/frontend/src/app/elite_bgs_api/docs/elite-bgs-api-docs.component.ts
+++ b/frontend/src/app/elite_bgs_api/docs/elite-bgs-api-docs.component.ts
@@ -1,6 +1,7 @@
 import { Component, HostBinding } from '@angular/core';
 import { Title } from '@angular/platform-browser';
 import { IInputSpec } from '../../swagger_ui/swagger-ui.component';
+import { environment } from 'environments/environment';
 
 @Component({
     selector: 'app-ebgs-api-docs',
@@ -14,28 +15,28 @@ export class EliteBgsApiDocsComponent {
         this.specs = [
             {
                 versionName: 'V1',
-                specLocation: '/api/ebgs/v1/api-docs.json',
-                swaggerLocation: '/api/ebgs/v1/docs'
+                specLocation: environment.apiUrl + '/api/ebgs/v1/api-docs.json',
+                swaggerLocation: environment.apiUrl + '/api/ebgs/v1/docs'
             },
             {
                 versionName: 'V2',
-                specLocation: '/api/ebgs/v2/api-docs.json',
-                swaggerLocation: '/api/ebgs/v2/docs'
+                specLocation: environment.apiUrl + '/api/ebgs/v2/api-docs.json',
+                swaggerLocation: environment.apiUrl + '/api/ebgs/v2/docs'
             },
             {
                 versionName: 'V3',
-                specLocation: '/api/ebgs/v3/api-docs.json',
-                swaggerLocation: '/api/ebgs/v3/docs'
+                specLocation: environment.apiUrl + '/api/ebgs/v3/api-docs.json',
+                swaggerLocation: environment.apiUrl + '/api/ebgs/v3/docs'
             },
             {
                 versionName: 'V4',
-                specLocation: '/api/ebgs/v4/api-docs.json',
-                swaggerLocation: '/api/ebgs/v4/docs'
+                specLocation: environment.apiUrl + '/api/ebgs/v4/api-docs.json',
+                swaggerLocation: environment.apiUrl + '/api/ebgs/v4/docs'
             },
             {
                 versionName: 'V5',
-                specLocation: '/api/ebgs/v5/api-docs.json',
-                swaggerLocation: '/api/ebgs/v5/docs'
+                specLocation: environment.apiUrl + '/api/ebgs/v5/api-docs.json',
+                swaggerLocation: environment.apiUrl + '/api/ebgs/v5/docs'
             }
         ]
     }

--- a/frontend/src/app/elite_bgs_api/overview/elite-bgs-api-overview.component.html
+++ b/frontend/src/app/elite_bgs_api/overview/elite-bgs-api-overview.component.html
@@ -16,13 +16,13 @@
         <div class="card-title">Endpoints</div>
         <div class="card-text">
             <h3>Factions</h3>
-            <code>https://elitebgs.app/api/ebgs/v5/factions?&lt;params&gt;</code>
+            <code>{{apiUrl}}/api/ebgs/v5/factions?&lt;params&gt;</code>
             <h3>Systems</h3>
-            <code>https://elitebgs.app/api/ebgs/v5/systems?&lt;params&gt;</code>
+            <code>{{apiUrl}}/api/ebgs/v5/systems?&lt;params&gt;</code>
             <h3>Stations</h3>
-            <code>https://elitebgs.app/api/ebgs/v5/stations?&lt;params&gt;</code>
+            <code>{{apiUrl}}/api/ebgs/v5/stations?&lt;params&gt;</code>
             <h3>Ticks</h3>
-            <code>https://elitebgs.app/api/ebgs/v5/ticks?&lt;params&gt;</code>
+            <code>{{apiUrl}}/api/ebgs/v5/ticks?&lt;params&gt;</code>
         </div>
     </div>
 </div>

--- a/frontend/src/app/elite_bgs_api/overview/elite-bgs-api-overview.component.ts
+++ b/frontend/src/app/elite_bgs_api/overview/elite-bgs-api-overview.component.ts
@@ -1,5 +1,6 @@
 import { Component, HostBinding } from '@angular/core';
 import { Title } from '@angular/platform-browser';
+import { environment } from 'environments/environment';
 
 @Component({
     selector: 'app-ebgs-api-overview',
@@ -10,4 +11,5 @@ export class EliteBgsApiOverviewComponent {
     constructor(private titleService: Title) {
         this.titleService.setTitle('Elite BGS API - Elite BGS');
     }
+    apiUrl = environment.apiUrl
 }

--- a/frontend/src/app/services/factions.service.ts
+++ b/frontend/src/app/services/factions.service.ts
@@ -3,6 +3,7 @@ import { HttpClient, HttpErrorResponse, HttpParams } from '@angular/common/http'
 import { Observable } from 'rxjs';
 import { EBGSFactionSchemaDetailed, EBGSFactionsDetailed, EBGSFactionsMinimal } from '../typings';
 import { CustomEncoder } from './custom.encoder';
+import { environment } from 'environments/environment';
 
 @Injectable()
 export class FactionsService {
@@ -11,13 +12,13 @@ export class FactionsService {
     }
 
     getFactionsBegins(page: string, name: string): Observable<EBGSFactionsMinimal> {
-        return this.http.get<EBGSFactionsMinimal>('/api/ebgs/v5/factions', {
+        return this.http.get<EBGSFactionsMinimal>(environment.apiUrl + '/api/ebgs/v5/factions', {
             params: new HttpParams({encoder: new CustomEncoder()}).set('page', page + 1).set('minimal', 'true').set('beginsWith', name)
         });
     }
 
     getFactionIdByEDDBId(eddbid: string): Observable<EBGSFactionsMinimal> {
-        return this.http.get<EBGSFactionsMinimal>('/api/ebgs/v5/factions', {
+        return this.http.get<EBGSFactionsMinimal>(environment.apiUrl + '/api/ebgs/v5/factions', {
             params: new HttpParams({encoder: new CustomEncoder()}).set('eddbId', eddbid).set('minimal', 'true')
         })
     }
@@ -31,13 +32,13 @@ export class FactionsService {
     }
 
     private getHistoryById(id: string, timeMin: string, timeMax: string): Observable<EBGSFactionsDetailed> {
-        return this.http.get<EBGSFactionsDetailed>('/api/ebgs/v5/factions', {
+        return this.http.get<EBGSFactionsDetailed>(environment.apiUrl + '/api/ebgs/v5/factions', {
             params: new HttpParams().set('id', id).set('timeMin', timeMin).set('timeMax', timeMax).set('systemDetails', 'true')
         });
     }
 
     private getHistory(name: string, timeMin: string, timeMax: string): Observable<EBGSFactionsDetailed> {
-        return this.http.get<EBGSFactionsDetailed>('/api/ebgs/v5/factions', {
+        return this.http.get<EBGSFactionsDetailed>(environment.apiUrl + '/api/ebgs/v5/factions', {
             params: new HttpParams({encoder: new CustomEncoder()}).set('name', name).set('timeMin', timeMin).set('timeMax', timeMax).set('systemDetails', 'true')
         });
     }

--- a/frontend/src/app/services/stations.service.ts
+++ b/frontend/src/app/services/stations.service.ts
@@ -3,6 +3,7 @@ import { HttpClient, HttpErrorResponse, HttpParams } from '@angular/common/http'
 import { Observable } from 'rxjs';
 import { EBGSStations, EBGSStationSchemaDetailed, EBGSStationsDetailed } from '../typings';
 import { CustomEncoder } from './custom.encoder';
+import { environment } from 'environments/environment';
 
 @Injectable()
 export class StationsService {
@@ -11,13 +12,13 @@ export class StationsService {
     }
 
     getStationsBegins(page: string, name: string): Observable<EBGSStations> {
-        return this.http.get<EBGSStations>('/api/ebgs/v5/stations', {
+        return this.http.get<EBGSStations>(environment.apiUrl + '/api/ebgs/v5/stations', {
             params: new HttpParams({encoder: new CustomEncoder()}).set('page', page + 1).set('beginsWith', name)
         });
     }
 
     getStationIdByEDDBId(eddbid: string): Observable<EBGSStations> {
-        return this.http.get<EBGSStations>('/api/ebgs/v5/stations', {
+        return this.http.get<EBGSStations>(environment.apiUrl + '/api/ebgs/v5/stations', {
             params: new HttpParams({encoder: new CustomEncoder()}).set('eddbId', eddbid).set('minimal', 'true')
         })
     }
@@ -31,13 +32,13 @@ export class StationsService {
     }
 
     private getHistoryById(id: string, timeMin: string, timeMax: string): Observable<EBGSStationsDetailed> {
-        return this.http.get<EBGSStationsDetailed>('/api/ebgs/v5/stations', {
+        return this.http.get<EBGSStationsDetailed>(environment.apiUrl + '/api/ebgs/v5/stations', {
             params: new HttpParams().set('id', id).set('timeMin', timeMin).set('timeMax', timeMax)
         });
     }
 
     private getHistory(name: string, timeMin: string, timeMax: string): Observable<EBGSStationsDetailed> {
-        return this.http.get<EBGSStationsDetailed>('/api/ebgs/v5/stations', {
+        return this.http.get<EBGSStationsDetailed>(environment.apiUrl + '/api/ebgs/v5/stations', {
             params: new HttpParams({encoder: new CustomEncoder()}).set('name', name).set('timeMin', timeMin).set('timeMax', timeMax)
         });
     }

--- a/frontend/src/app/services/systems.service.ts
+++ b/frontend/src/app/services/systems.service.ts
@@ -3,6 +3,7 @@ import { HttpClient, HttpErrorResponse, HttpParams } from '@angular/common/http'
 import { Observable } from 'rxjs';
 import { EBGSSystemSchemaDetailed, EBGSSystemsDetailed, EBGSSystemsMinimal } from '../typings';
 import { CustomEncoder } from './custom.encoder';
+import { environment } from 'environments/environment';
 
 @Injectable()
 export class SystemsService {
@@ -11,13 +12,13 @@ export class SystemsService {
     }
 
     getSystemsBegins(page: string, name: string): Observable<EBGSSystemsMinimal> {
-        return this.http.get<EBGSSystemsMinimal>('/api/ebgs/v5/systems', {
+        return this.http.get<EBGSSystemsMinimal>(environment.apiUrl + '/api/ebgs/v5/systems', {
             params: new HttpParams({encoder: new CustomEncoder()}).set('page', page + 1).set('minimal', 'true').set('beginsWith', name)
         });
     }
 
     getSystemIdByEDDBId(eddbid: string): Observable<EBGSSystemsMinimal> {
-        return this.http.get<EBGSSystemsMinimal>('/api/ebgs/v5/systems', {
+        return this.http.get<EBGSSystemsMinimal>(environment.apiUrl + '/api/ebgs/v5/systems', {
             params: new HttpParams({encoder: new CustomEncoder()}).set('eddbId', eddbid).set('minimal', 'true')
         })
     }
@@ -31,13 +32,13 @@ export class SystemsService {
     }
 
     private getHistoryById(id: string, timeMin: string, timeMax: string): Observable<EBGSSystemsDetailed> {
-        return this.http.get<EBGSSystemsDetailed>('/api/ebgs/v5/systems', {
+        return this.http.get<EBGSSystemsDetailed>(environment.apiUrl + '/api/ebgs/v5/systems', {
             params: new HttpParams().set('id', id).set('timeMin', timeMin).set('timeMax', timeMax).set('factionDetails', 'true').set('factionHistory', 'true')
         });
     }
 
     private getHistory(name: string, timeMin: string, timeMax: string): Observable<EBGSSystemsDetailed> {
-        return this.http.get<EBGSSystemsDetailed>('/api/ebgs/v5/systems', {
+        return this.http.get<EBGSSystemsDetailed>(environment.apiUrl + '/api/ebgs/v5/systems', {
             params: new HttpParams({encoder: new CustomEncoder()}).set('name', name).set('timeMin', timeMin).set('timeMax', timeMax).set('factionDetails', 'true').set('factionHistory', 'true')
         });
     }

--- a/frontend/src/app/services/tick.service.ts
+++ b/frontend/src/app/services/tick.service.ts
@@ -4,6 +4,7 @@ import { Observable } from 'rxjs';
 import { Tick, TickSchema, TickDisplaySchema } from '../typings';
 import { CustomEncoder } from './custom.encoder';
 import * as moment from 'moment';
+import { environment } from 'environments/environment';
 
 @Injectable()
 export class TickService {
@@ -13,11 +14,11 @@ export class TickService {
     ) { }
 
     getTick(): Observable<Tick> {
-        return this.http.get<Tick>('/api/ebgs/v5/ticks');
+        return this.http.get<Tick>(environment.apiUrl + '/api/ebgs/v5/ticks');
     }
 
     getTicks(timemin: string, timemax: string): Observable<Tick> {
-        return this.http.get<Tick>('/api/ebgs/v5/ticks', {
+        return this.http.get<Tick>(environment.apiUrl + '/api/ebgs/v5/ticks', {
             params: new HttpParams({ encoder: new CustomEncoder() }).set('timeMin', timemin).set('timeMax', timemax)
         });
     }

--- a/frontend/src/environments/environment.prod.ts
+++ b/frontend/src/environments/environment.prod.ts
@@ -3,5 +3,6 @@ import { version } from './version';
 export const environment = {
     production: true,
     version: version,
-    baseUrl: 'https://elitebgs.app'
+    baseUrl: 'https://elitebgs.app',
+    apiUrl: 'https://elitebgs.app'
 };

--- a/frontend/src/environments/environment.ts
+++ b/frontend/src/environments/environment.ts
@@ -7,5 +7,6 @@ import { version } from './version';
 export const environment = {
     production: false,
     version: version,
-    baseUrl: 'http://localhost:3014'
+    baseUrl: 'http://localhost:3014',
+    apiUrl: 'http://localhost:3010'
 };


### PR DESCRIPTION
This change allows EliteBGS to run again on local development. By adding the environment.apiUrl wherever the EliteBGS API is called, this change allows the code to succeed without relying upon a local nginx or other URL router that can aggregate multiple routes into the same place. 